### PR TITLE
Handle duplicate boundary points in the mark_boundary method

### DIFF
--- a/limited_area/limited_area.py
+++ b/limited_area/limited_area.py
@@ -396,6 +396,11 @@ class LimitedArea():
             sourceCell = boundaryCells[i]
             targetCell = boundaryCells[(i + 1) % len(boundaryCells)]
 
+            # If we are already at the next target cell, there is no need
+            # to connect sourceCell with targetCell, and we can skip to
+            # the next pair of boundary points
+            if sourceCell == targetCell:
+                continue
 
             pta = latlon_to_xyz(latCell[sourceCell], 
                                 lonCell[sourceCell], 


### PR DESCRIPTION
This merge adds logic to allow the `mark_boundary` method to handle
duplicate boundary points.

If the list of boundary points contains consecutive locations that
lie within the same MPAS grid cell, the computation to create a path
from the first cell to its successor will result in a divide by zero
in the following code:
```
            pta = np.cross(pta, ptb)
            temp = np.linalg.norm(pta)
            cross = pta / temp
```
To handle duplicate boundary points, we now check whether the MPAS
cell index for the sourceCell and targetCell are the same, and if
they are, we can skip the processing of the pair of points.