### PR TITLE
Correct two issues in copying global attributes from input to output mesh

### DIFF
--- a/limited_area/mesh.py
+++ b/limited_area/mesh.py
@@ -147,17 +147,6 @@ class MeshHandler:
 
         print(graphFname)
 
-    def copy_global_attributes(self, region):
-        """ Copy the global attributes into the regional mesh, but not 'np' """
-        region.mesh.np = region.mesh.dimensions['nCells'].size
-
-        region.mesh.on_a_sphere = self.mesh.on_a_sphere
-        region.mesh.sphere_radius = self.mesh.sphere_radius
-        region.mesh.n_scvt_iterations = self.mesh.n_scvt_iterations
-        region.mesh.eps = self.mesh.eps
-        region.mesh.Convergence = self.mesh.Convergence
-
-
     def subset_fields(self, 
                       regionalFname, 
                       bdyMaskCell,

--- a/limited_area/mesh.py
+++ b/limited_area/mesh.py
@@ -291,13 +291,8 @@ class MeshHandler:
 
     def copy_global_attributes(self, region):
         """ Copy the global attributes into the regional mesh, but not 'np' """
-        region.mesh.np = region.mesh.dimensions['nCells'].size
-
         region.mesh.on_a_sphere = self.mesh.on_a_sphere
         region.mesh.sphere_radius = self.mesh.sphere_radius
-        region.mesh.n_scvt_iterations = self.mesh.n_scvt_iterations
-        region.mesh.eps = self.mesh.eps
-        region.mesh.Convergence = self.mesh.Convergence
 
 
 def scan(arr):


### PR DESCRIPTION
This merge corrects two small issues in the code to copy global attributes
from the input mesh to the output mesh:
1) Some attributes that are not needed by MPAS-Atmosphere, and which are in fact
not present in all meshes, were being copied; now, only the `on_a_sphere` and
`sphere_radius` attributes are copied.
2) The was a duplicate copy of the `copy_global_attributes` method in the `MeshHandler`
class that has been deleted.