### PR TITLE
Fix issue in copying un-subsetted variables to output file

### DIFF
--- a/limited_area/mesh.py
+++ b/limited_area/mesh.py
@@ -348,7 +348,7 @@ class MeshHandler:
                     region.mesh.variables[var][:] = arrTemp[glbBdyVertexIDs]
             else:
                 print('')
-                region.mesh.variables[var][:] = arrTemp[var]
+                region.mesh.variables[var][:] = arrTemp[:]
 
 
         return region


### PR DESCRIPTION
This merge corrects an issue in copying un-subsetted variables.

When copying fields that should not be subsetted (i.e., those fields
that don't have any of nCells, nEdges, or nVertices as one of their
dimensions), the syntax for accessing arrTemp incorrectly used
the name of the variable as an index.