### PR TITLE
Equatorial channel method and process multiple boundaries

### DIFF
--- a/limited_area/points.py
+++ b/limited_area/points.py
@@ -93,6 +93,8 @@ def PointsParser(self, file, *args, **kwargs):
                     self.type = 'custom'
                 elif rhs == 'Square' or rhs == 'square':
                     self.type = 'square'
+                elif rhs == 'Channel' or rhs == 'channel':
+                    self.type = 'channel'
                 elif rhs == 'Circle' or rhs == 'circle':
                     self.type = 'circle'
                 elif rhs == 'Ellipse' or rhs == 'ellipse':
@@ -107,7 +109,10 @@ def PointsParser(self, file, *args, **kwargs):
                                      float(rhs.split(',')[1])]
             elif lhs == 'Radius' or lhs == 'radius':
                 self.radius = float(rhs)
-
+            elif lhs == 'uLat' or lhs == 'Upper Lat' or lhs == 'ulat':
+                self.ulat = float(rhs)
+            elif lhs == 'lLat' or lhs == 'Lower Lat:' or lhs == 'llat':
+                self.llat = float(rhs)
         elif line == 'keyword': # Then we have a keyword option
             pass
         elif ',' in line: # Then we have a coordinate point

--- a/limited_area/region_spec.py
+++ b/limited_area/region_spec.py
@@ -129,7 +129,7 @@ class RegionSpec:
                                                         self.in_point[0],
                                                         self.in_point[1])
 
-                return self.name, self.in_point, self.points
+                return self.name, self.in_point, [self.points]
             elif self.type == 'square':
                 return self.square()
             elif self.type == 'circle':
@@ -144,7 +144,7 @@ class RegionSpec:
                 self.radius = (self.radius * 1000) / EARTH_RADIUS
                 self.points = self.circle(self.in_point[0], self.in_point[1], self.radius)
 
-                return self.name, self.in_point, self.points.flatten()
+                return self.name, self.in_point, [self.points.flatten()]
 
             elif self.type == 'ellipse':
                 return self.ellipse()

--- a/limited_area/region_spec.py
+++ b/limited_area/region_spec.py
@@ -148,8 +148,36 @@ class RegionSpec:
 
             elif self.type == 'ellipse':
                 return self.ellipse()
+            elif self.type == 'channel':
+                if self._DEBUG_ > 0:
+                    print("DEBUG: Using the channel method for region generation")
 
+                if self.ulat == self.llat:
+                    print("ERROR: Upper and lower lattiude for channel specification")
+                    print("ERROR: can not be equal")
+                    print("ERROR: ulat: ", self.ulat)
+                    print("ERROR: llat: ", self.llat)
+                    sys.exit(-1)
 
+                self.ulat, self.llat = normalize_cords(self.ulat, self.llat)
+
+                self.boundaries = []
+
+                upperBdy = np.empty([100, 2])
+                lowerBdy = np.empty([100, 2])
+
+                upperBdy[:,0] = self.ulat
+                upperBdy[:,1] = np.linspace(0.0, 2.0 * np.pi, 100)
+
+                lowerBdy[:,0] = self.llat
+                lowerBdy[:,1] = np.linspace(0.0, 2.0 * np.pi, 100)
+
+                self.in_point = np.array([(self.ulat + self.llat) / 2, 0])
+
+                self.boundaries.append(upperBdy.flatten())
+                self.boundaries.append(lowerBdy.flatten())
+        
+                return self.name, self.in_point, self.boundaries
 
     def circle(self, center_lat, center_lon, radius):
         """ Return a list of latitude and longitude points in degrees that
@@ -209,3 +237,4 @@ class RegionSpec:
     def ellipse(self):
         """ """
         raise NotImplementedError("ELLIPSE FUNCITON "+NOT_IMPLEMENTED_ERROR)
+


### PR DESCRIPTION
This PR includes the ability to process multiple boundaries and the ability to specify a equatorial channel.

Region specifications will now need to return a list of boundaries, and not just a single list of boundary points.