### PR TITLE
Add the ability to specify an equatorial channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,31 @@ Point: 40.0, -105.5
 radius: 4000
 ```
 
-# Reporting Bugs<a name="bugs">
+## Equatorial Channel
+
+The equatorial channel method can be used to specify a channel parallel to the
+equator, across longitudes and between two latitude points.
+
+For instance, one can specify a region between the tropics as:
+
+```
+Name: tropics
+Type: channel
+Upper-lat: 23.43676
+lower-lat: -23.43676
+```
+
+### **Caution on creating channels of `grid.nc` files**
+
+Depending on the location of a specified channel, erroneous results can be
+caused during some interpolation static fields by the init_atmosphere core.
+This will cause erroneous results within result `static.nc` files and will
+cause resulting files to be unusable.
+
+Thus, it is **highly** recommended to only use the channel method upon
+`static.nc` files. Doing so will avoid this problem and will also save time
+interpolating the static fields on different regions.
+
+# Reporting Bugs
 
 If you encounter a bug and wish to report it, please do so on this Github repository's Issues page! Thank you!

--- a/docs/points-examples/tropics.channel.pts
+++ b/docs/points-examples/tropics.channel.pts
@@ -1,0 +1,4 @@
+Name: tropics
+Type: channel
+ulat: 23.43676
+llat: -23.43676

--- a/limited_area/points.py
+++ b/limited_area/points.py
@@ -91,6 +91,8 @@ def PointsParser(self, file, *args, **kwargs):
             elif lhs == 'Type' or lhs == 'type':
                 if rhs == 'Custom' or rhs == 'custom':
                     self.type = 'custom'
+                elif rhs == 'Channel' or rhs == 'channel':
+                    self.type = 'channel'
                 elif rhs == 'Circle' or rhs == 'circle':
                     self.type = 'circle'
                 else:
@@ -103,7 +105,10 @@ def PointsParser(self, file, *args, **kwargs):
                                      float(rhs.split(',')[1])]
             elif lhs == 'Radius' or lhs == 'radius':
                 self.radius = float(rhs)
-
+            elif lhs == 'uLat' or lhs == 'Upper-lat' or lhs == 'upper-lat' or lhs == 'ulat':
+                self.ulat = float(rhs)
+            elif lhs == 'lLat' or lhs == 'Lower-lat' or lhs == 'lower-lat' or lhs == 'llat':
+                self.llat = float(rhs)
         elif line == 'keyword': # Then we have a keyword option
             pass
         elif ',' in line: # Then we have a coordinate point

--- a/limited_area/region_spec.py
+++ b/limited_area/region_spec.py
@@ -109,12 +109,41 @@ class RegionSpec:
                                                     self.in_point[0],
                                                     self.in_point[1])
 
-
             # Convert to meters, then divide by radius to get radius upon sphere w/ r = 1
             self.radius = (self.radius * 1000) / EARTH_RADIUS
             self.points = self.circle(self.in_point[0], self.in_point[1], self.radius)
 
             return self.name, self.in_point, [self.points.flatten()]
+        elif self.type == 'channel':
+            if self._DEBUG_ > 0:
+                print("DEBUG: Using the channel method for region generation")
+
+            if self.ulat == self.llat:
+                print("ERROR: Upper and lower latitude for channel specification")
+                print("ERROR: cannot be equal")
+                print("ERROR: Upper-lat: ", self.ulat)
+                print("ERROR: Lower-lat: ", self.llat)
+                sys.exit(-1)
+
+            self.ulat, self.llat = normalize_cords(self.ulat, self.llat)
+
+            self.boundaries = []
+
+            upperBdy = np.empty([100, 2])
+            lowerBdy = np.empty([100, 2])
+
+            upperBdy[:,0] = self.ulat
+            upperBdy[:,1] = np.linspace(0.0, 2.0 * np.pi, 100)
+
+            lowerBdy[:,0] = self.llat
+            lowerBdy[:,1] = np.linspace(0.0, 2.0 * np.pi, 100)
+
+            self.in_point = np.array([(self.ulat + self.llat) / 2, 0])
+
+            self.boundaries.append(upperBdy.flatten())
+            self.boundaries.append(lowerBdy.flatten())
+
+            return self.name, self.in_point, self.boundaries
 
     def circle(self, center_lat, center_lon, radius):
         """ Return a list of latitude and longitude points in degrees that
@@ -164,4 +193,3 @@ class RegionSpec:
             ll.append(xyz_to_latlon(P[i])) # Convert back to latlon
 
         return np.array(ll)
-


### PR DESCRIPTION
This commit adds the ability to specify an equatorial channel, a channel between two latitudes.

This method can create meshes that fail with the current 7.0 static interpolation. If regions are significantly close to the poles, the static interpolation will assign erroneous values to the wrong locations.