### PR TITLE
Add abilty to create regions from .static.nc files

### DIFF
--- a/limited_area/limited_area.py
+++ b/limited_area/limited_area.py
@@ -165,14 +165,19 @@ class LimitedArea():
 
     def create_partiton_fname(self, name, mesh, **kwargs):
         """ Generate the filename for the regional graph.info file"""
-        nCells = mesh.mesh.dimensions['nCells'].size
-        return name+'.'+str(nCells)+'.graph.info'
+        return name+'.graph.info'
         
 
     def create_regional_fname(self, name, mesh, **kwargs):
         """ Generate the filename for the regional mesh file """
-        nCells = mesh.mesh.dimensions['nCells'].size
-        return name+'.'+str(nCells)+'.grid.nc'
+        if 'static' in mesh.fname and not 'grid' in mesh.fname:
+            meshType = 'static'
+        elif 'grid' in mesh.fname and not 'static' in mesh.fname:
+            meshType = 'grid'
+        else:
+            meshType = 'region'
+
+        return name+'.'+meshType+'.nc'
 
 
     # Mark_neighbors_search - Faster for smaller regions ??

--- a/limited_area/limited_area.py
+++ b/limited_area/limited_area.py
@@ -347,14 +347,14 @@ class LimitedArea():
 
             pta = latlon_to_xyz(mesh.latCells[sourceCell],
                                 mesh.lonCells[sourceCell],
-                                mesh.sphere_radius)
+                                1.0)
             ptb = latlon_to_xyz(mesh.latCells[targetCell],
                                 mesh.lonCells[targetCell],
-                                mesh.sphere_radius)
+                                1.0)
         
             pta = np.cross(pta, ptb)
             temp = np.linalg.norm(pta)
-            cross = pta / temp
+            pta = pta / temp
             iCell = sourceCell
             while iCell != targetCell:
                 bdyMaskCell[iCell] = self.INSIDE
@@ -363,17 +363,17 @@ class LimitedArea():
                                           mesh.lonCells[iCell],
                                           mesh.latCells[targetCell],
                                           mesh.lonCells[targetCell],
-                                          mesh.sphere_radius)
+                                          1.0)
                 for j in range(mesh.nEdgesOnCell[iCell]):
                     v = mesh.cellsOnCell[iCell, j] - 1
                     dist = sphere_distance(mesh.latCells[v],
                                            mesh.lonCells[v],
                                            mesh.latCells[targetCell],
                                            mesh.lonCells[targetCell],
-                                           mesh.sphere_radius)
+                                           1.0)
                     if dist > mindist:
                         continue
-                    pt = latlon_to_xyz(mesh.latCells[v], mesh.lonCells[v], mesh.sphere_radius)
+                    pt = latlon_to_xyz(mesh.latCells[v], mesh.lonCells[v], 1.0)
                     angle = np.dot(pta, pt)
                     angle = abs(0.5 * np.pi - np.arccos(angle))
                     if angle < minangle:

--- a/limited_area/mesh.py
+++ b/limited_area/mesh.py
@@ -271,8 +271,12 @@ class MeshHandler:
                 region.mesh.createDimension(dim, 
                                             len(glbBdyVertexIDs))
             else:
-                region.mesh.createDimension(dim,
-                                            self.mesh.dimensions[dim].size)
+                if self.mesh.dimensions[dim].isunlimited():
+                    region.mesh.createDimension(dim,
+                                                None)
+                else:
+                    region.mesh.createDimension(dim,
+                                                self.mesh.dimensions[dim].size)
 
         # Make boundary Mask's between 0 and the number of specified relaxation
         # layers

--- a/limited_area/mesh.py
+++ b/limited_area/mesh.py
@@ -294,17 +294,26 @@ class MeshHandler:
 
         # Variables - Create Variables
         for var in self.mesh.variables:
-            region.mesh.createVariable(var, self.mesh.variables[var].dtype,
-                                            self.mesh.variables[var].dimensions)
-            try:
-                region.mesh.variables[var].units = self.mesh.variables[var].units
-                region.mesh.variables[var].long_name = self.mesh.variables[var].long_name
-            except:
-                pass
+            # If we're subsetting a static file, don't copy variables for bdyMaskCell,
+            # bdyMaskEdge or bdyMaskVertex if they exist in the static file as they have
+            # been created by this program
+            if var != 'bdyMaskCell' and var != 'bdyMaskEdge' and var != 'bdyMaskVertex':
+                region.mesh.createVariable(var, self.mesh.variables[var].dtype,
+                                                self.mesh.variables[var].dimensions)
+                try:
+                    region.mesh.variables[var].units = self.mesh.variables[var].units
+                    region.mesh.variables[var].long_name = self.mesh.variables[var].long_name
+                except:
+                    pass
 
         # Subset global variables into the regional mesh and write them
         # to the regional mesh - re-indexing if necessary
         for var in self.mesh.variables:
+            # If subsetting a static file, don't copy any bdyMask variables, as we
+            # created them above
+            if var == 'bdyMaskCell' or var == 'bdyMaskEdge' or var == 'bdyMaskVertex':
+                continue
+
             print("Copying variable ", var, "...", end=' ', sep=''); sys.stdout.flush()
             if var in self.variables:
                 arrTemp = self.variables[var] # Use the pre-loaded variable if possible

--- a/limited_area/mesh.py
+++ b/limited_area/mesh.py
@@ -346,7 +346,7 @@ class MeshHandler:
                     region.mesh.variables[var][:] = arrTemp[glbBdyVertexIDs]
             else:
                 print('')
-                region.mesh.variables[var][:] = arrTemp[:]
+                region.mesh.variables[var][:] = arrTemp
 
 
         return region

--- a/limited_area/mesh.py
+++ b/limited_area/mesh.py
@@ -296,6 +296,11 @@ class MeshHandler:
         for var in self.mesh.variables:
             region.mesh.createVariable(var, self.mesh.variables[var].dtype,
                                             self.mesh.variables[var].dimensions)
+            try:
+                region.mesh.variables[var].units = self.mesh.variables[var].units
+                region.mesh.variables[var].long_name = self.mesh.variables[var].long_name
+            except:
+                pass
 
         # Subset global variables into the regional mesh and write them
         # to the regional mesh - re-indexing if necessary


### PR DESCRIPTION
This PR contains a number of commits that enable the ability to creation a region from a global file that contains static fields. 

First, we fix a bug where unlimited dimensions were not correctly being copied. For `grid.nc` files this was not needed as there were no unlimited dimensions.

Next, we normalize `LimitedArea.mark_boundary` to work upon any sized sphere by normalizing its vectors to be unit sphere vectors.

Then, we add logic in to not copy 'bdyMask' fields that may be within the static file. We do not want to copy these fields as we are creating the three `bdyMask` fields. We also added in a fix to correctly copy scalar fields.

Lastly, we changed the name of the output file from `region_name.nCells.graph.nc` to `region_name.nCells.region.nc`. @mgduda Do you have a preference on the output filename? Perhaps it is possible for the LimitedArea program to determine if the input file is either a `grid.nc` or a `static.nc` and name its region appropriately: i.e. `conus.2562.grid.nc` or `conus.2562.static.nc`.

This PR closes issue #25 and enables us to merge in PR #24.