### PR TITLE
Subset fields dimensioned by time

### DIFF
--- a/limited_area/mesh.py
+++ b/limited_area/mesh.py
@@ -322,7 +322,10 @@ class MeshHandler:
                     print('Done!')
                 else:
                     print('')
-                    region.mesh.variables[var][:] = arrTemp[glbBdyCellIDs]
+                    if 'Time' in region.mesh.variables[var].dimensions:
+                        region.mesh.variables[var][:] = arrTemp[:, glbBdyCellIDs]
+                    else:
+                        region.mesh.variables[var][:] = arrTemp[glbBdyCellIDs]
             elif 'nEdges' in self.mesh.variables[var].dimensions:
                 if var in indexingFields:
                     region.mesh.variables[var][:] = reindex_field(arrTemp[glbBdyEdgeIDs], 
@@ -330,7 +333,10 @@ class MeshHandler:
                     print('Done!')
                 else:
                     print('')
-                    region.mesh.variables[var][:] = arrTemp[glbBdyEdgeIDs]
+                    if 'Time' in region.mesh.variables[var].dimensions:
+                        region.mesh.variables[var][:] = arrTemp[:, glbBdyEdgeIDs]
+                    else:
+                        region.mesh.variables[var][:] = arrTemp[glbBdyEdgeIDs]
             elif 'nVertices' in self.mesh.variables[var].dimensions:
                 if var in indexingFields:
                     region.mesh.variables[var][:] = reindex_field(arrTemp[glbBdyVertexIDs], 
@@ -338,7 +344,10 @@ class MeshHandler:
                     print('Done!')
                 else:
                     print('')
-                    region.mesh.variables[var][:] = arrTemp[glbBdyVertexIDs]
+                    if 'Time' in region.mesh.variables[var].dimensions:
+                        region.mesh.variables[var][:] = arrTemp[:, glbBdyVertexIDs]
+                    else:
+                        region.mesh.variables[var][:] = arrTemp[glbBdyVertexIDs]
             else:
                 print('')
                 region.mesh.variables[var][:] = arrTemp


### PR DESCRIPTION
This commit adds changes to successfully subset fields that are dimensioned by
Time. Before, if a field was dimensioned by Time an error would occur because the
region masks (either glbBdyCellIDs, glbBdyVertexIDs or glbBdyEdgeIDs) would be
subsetting the Time dimensioned and not the nCells, nVertices or nEdges
dimension.

This commit fixes the above by checking to see if the time dimension is in the
new variable we are copying and using the region masks to subset the second
nCells, nVertices or nEdges dimension.