### PR TITLE
Change specification for circle radius from kilometers to meters

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,21 +175,21 @@ An example circle points specification would look like the following:
 ```
 Name: my_circle
 Type: circle
-Point: -40.0, 105.5
-Radius: 3000
+Point: 53.5, -4.5
+Radius: 655000.0 # Meters
 ```
 
 Here `Point` is used to specify the center of the circle and `Radius` is used
-to specify the radius of the circle (in kilometers). **NOTE**: The radius must
+to specify the radius of the circle (in meters). **NOTE**: The radius must
 be larger then at least the smallest grid cell, else unexpected behavior will
 occur.
 
-An example circle method for defining a circle around Boulder, Colorado is:
+An example circle method for defining a circle around Colorado, USA is:
 ```
-Name: boulder
+Name: colorado
 Type: circle
-Point: 40.0, -105.5
-radius: 4000
+Point: 40.0, -105.0
+radius: 400000.0
 ```
 
 ## Ellipse<a name='ellipse'>

--- a/docs/points-examples/india.circle.pts
+++ b/docs/points-examples/india.circle.pts
@@ -1,4 +1,4 @@
 Name: india
 Type: circle
 Point: 20.0, 80.0
-radius: 2000
+radius: 2000000.0   # Meters

--- a/docs/points-examples/japan.ellipse.pts
+++ b/docs/points-examples/japan.ellipse.pts
@@ -1,6 +1,6 @@
 Name: japan
 Type: ellipse
 Point: 38.0, 138.0
-Semi-major-axis: 1580000
-Semi-minor-axis: 1000000
+Semi-major-axis: 1580000    # Meters
+Semi-minor-axis: 1000000    # Meters
 Orientation-angle: 45

--- a/limited_area/region_spec.py
+++ b/limited_area/region_spec.py
@@ -108,8 +108,8 @@ class RegionSpec:
                                                     self.in_point[0],
                                                     self.in_point[1])
 
-            # Convert to meters, then divide by radius to get radius upon sphere w/ r = 1
-            self.radius = (self.radius * 1000) / EARTH_RADIUS
+            # Divide by sphere radius to get radius upon sphere
+            self.radius = self.radius / EARTH_RADIUS
             self.points = self.circle(self.in_point[0], self.in_point[1], self.radius)
             return self.name, self.in_point, [self.points.flatten()]
         elif self.type == 'ellipse':


### PR DESCRIPTION
These commits changes the way points circle method radius is specified from kilometers to meters. This change is to be more consistent across points methods (for instances distances specified in the ellipse radius) as well as distances specified in the MPAS-A model, specifically `config_len_disp`.