### PR TITLE
Add ability to subset multiple files in a single call

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # MPAS Limited-Area - v2.1
 
-MPAS Limited-Area is a python tool that takes an MPAS global grid and produces
-a regional area grid given a region specifications. Regions can be specified in
-a number of different ways, making limited-area extensible and flexible.
+MPAS Limited-Area is a Python tool that takes MPAS global mesh files and
+can produce regional subsets meshes given a region specifications. The MPAS
+Limited-Area tool can create subsets MPAS mesh files that contain time variant,
+and time invariant fields, given a mesh connectivity fields are present.
+
+Regional specifications can be created in a number of ways, making limited-area
+extensible and flexible.
 
 # Download and Installing<a name="Installing"/>
 
@@ -18,8 +22,8 @@ $ setenv PATH ${PATH}:/path/to/MPAS-Limited-Area
 Then, run the `create_region` command-line script:
 ```Bash
 $ # Running the script with no arguments will produce a usage output
-Usage: create_region [-h] [-v VERBOSE] points grid create_region
-create_region: error: the following arguments are required: points, grid
+usage: create_region [-h] [-v VERBOSE] points files [files ...]
+create_region: error: the following arguments are required: points, files
 ```
 
 **Note**: It may be necessary to install the dependencies for this program if
@@ -51,20 +55,43 @@ to generate a help message, usage statement and a list of options. The command
 line usage is:
 
 ``` bash
-$ create_region [options] points grid
+usage: create_region [-h] [-v VERBOSE] points files [files ...]
 ```
 
-Where `points` is a points specification file, and where `grid` is a global
-MPAS NetCDF grid file. You'll find example points file in the points-example
-directory within the docs directory of this repository and below in the *Points
-Syntax* section.
+Where `points` is a points specification file, and where `files` is any number
+of global MPAS NetCDF mesh files with the first containing the mesh
+connectivity information that will be used subset itself and the others.
+
+You can find example points file in the points-example directory within the
+docs directory of this repository and below in the *Points Syntax* section.
+
+## Example Subsetting Mesh Files
+
+MPAS-Limited-Area can subset single or multiple files:
+
+``` bash
+# Subset a mesh file with only connectivity information:
+create_region conus.circle.pts x1.10242.grid.nc
+
+# Subset a static file with time invariant fields:
+create_region conus.circle.pts x1.10242.static.nc
+
+# Subset an initial conditions files with time invariant and time variant
+# fields:
+create_region conus.circle.pts x1.10242.init.nc
+
+# Subset files that do not contain mesh connectivity (as well as the mesh that
+# contains mesh connectivity fields):
+create_region conus.circle.pts x1.10242.init.nc diag.2019-01-28_00.00.00.nc
+diag.2019-01-28_03.00.00.nc diag.2019-01-28-06.00.00.nc
+```
 
 ## Notes on creating regions from .grid.nc files<a name="concave">
 
 When creating region subsets from `grid.nc` files, it is important to take a
-few things into account. Because of the way the init_atmosphere model 
+few things into account. Because of the way the init_atmosphere model
 interpolates some static data, it is possible to create incorrect static
-feilds on a concave mesh, during the static interpolation of the 
+fields on a concave mesh, during the static interpolation of the
 init_atmosphere model.
 
 Creating a mesh that is either **concave** in overall shape, or spans
@@ -115,7 +142,7 @@ appropriate value:
                of the circle and ellipse. `Point` is not used with the channel
                method.
 
-The value after `Name:` will be the name of the new regional mesh. 
+The value after `Name:` will be the name of the new regional mesh.
 
 If the `Name` within the pts file was set to be the following:
 ```

--- a/create_region
+++ b/create_region
@@ -27,9 +27,9 @@ if __name__ == "__main__":
     required.add_argument('points',
                           help='Points file specifying the MPAS regional area',
                           type=str)
-    required.add_argument('grid',
-                          help=('Global MPAS grid file. Either a grid.nc or'
-                                ' static.nc file'),
+    required.add_argument('files',
+                          help=('Global MPAS file(s) to be subset'),
+                          nargs='+',
                           type=str)
 
     options.add_argument('-v', '--verbose',
@@ -45,13 +45,13 @@ if __name__ == "__main__":
         print("DEBUG: DEBUG set to verbose level ", DEBUG, '\n')
 
     if DEBUG > 1:
-        print("DEBUG: Grid File: ", args.grid)
+        print("DEBUG: Grid File: ", args.files)
         print("DEBUG: Points File: ", args.points)
 
 
     kwargs = { 'DEBUG' : DEBUG }
 
-    regional_area = LimitedArea(args.grid,
+    regional_area = LimitedArea(args.files,
                                 args.points,
                                 format='NETCDF3_64BIT_OFFSET',
                                 **kwargs)

--- a/create_region
+++ b/create_region
@@ -5,8 +5,9 @@ import argparse
 from limited_area.limited_area import LimitedArea
 
 if __name__ == "__main__":
-    description = ("Create a limited area MPAS grid from a global MPAS grid"
-                   " and a file that specifies the regional area boundary.")
+    description = ("Create regional subsets of global MPAS meshes using "
+                   "a regional specification .pts file that specifies the "
+                   "regions boundary.")
 
     epilog = ("For more information please see: "
              "https://github.com/MiCurry/MPAS-Limited-Area")
@@ -15,20 +16,22 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=description,
                                      epilog=epilog)
 
-    required = parser.add_argument_group('Required', "Limited Area requires a"
-                                                     " MPAS Grid as well as a"
-                                                     " file specifying the"
-                                                     " limited area.")
+    required_description = ("create_region requires a MPAS mesh file that "
+                            "contains mesh connectivity fields and a file for "
+                            "specifying a regional area (.pts file). ")
 
-    options = parser.add_argument_group('Options', "Options to generating the"
-                                                   " MPAS limited area.")
+    required = parser.add_argument_group('Required', required_description)
 
+    options = parser.add_argument_group('Options')
 
     required.add_argument('points',
                           help='Points file specifying the MPAS regional area',
                           type=str)
     required.add_argument('files',
-                          help=('Global MPAS file(s) to be subset'),
+                          help=('Global MPAS file(s) to be subset. If multiple '
+                          'meshes are given, the first must contain mesh '
+                          'connectivity infromation that will be used to '
+                          'subset all files.'),
                           nargs='+',
                           type=str)
 
@@ -45,7 +48,7 @@ if __name__ == "__main__":
         print("DEBUG: DEBUG set to verbose level ", DEBUG, '\n')
 
     if DEBUG > 1:
-        print("DEBUG: Grid File: ", args.files)
+        print("DEBUG: Mesh Files: ", args.files)
         print("DEBUG: Points File: ", args.points)
 
 

--- a/limited_area/limited_area.py
+++ b/limited_area/limited_area.py
@@ -164,7 +164,7 @@ class LimitedArea():
 
         # Subset the grid into a new region:
         print('Subsetting mesh fields into the specified region mesh...')
-        regionFname = self.create_regional_fname(name, self.mesh)
+        regionFname = self.create_regional_fname(name, self.mesh.fname)
         regionalMesh = self.mesh.subset_fields(regionFname,
                                           bdyMaskCell,
                                           bdyMaskEdge,
@@ -194,26 +194,10 @@ class LimitedArea():
         return name+'.graph.info'
         
 
-    def create_regional_fname(self, name, mesh, **kwargs):
-        """ Generate the filename for the regional mesh file. Depending on what "type" of MPAS file
-        we are using, either static, grid or init, try to rename the region file as that type (i.e.
-        x1.2562.static.nc becomes name.static.nc).
-        
-        If a file name is ambiguous, or the file name does not contain: static, init, or grid,
-        rename the region file to be region. """
-        # Static files
-        if 'static' in mesh.fname and not ('grid' in mesh.fname or 'init' in mesh.fname):
-            meshType = 'static'
-        # Grid files
-        elif 'grid' in mesh.fname and not ('static' in mesh.fname or 'init' in mesh.fname):
-            meshType = 'grid'
-        # Initialization Data
-        elif 'init' in mesh.fname and not ('static' in mesh.fname or 'grid' in mesh.fname):
-            meshType = 'init'
-        else:
-            meshType = 'region'
-
-        return name+'.'+meshType+'.nc'
+    def create_regional_fname(self, regionName, meshFileName, **kwargs):
+        """ Create the regional file name by prepending the regional name
+        (specified by Name: ) in the points file, to the meshFileName. """
+        return regionName+'.'+meshFileName
 
 
     # Mark_neighbors_search - Faster for smaller regions ??

--- a/limited_area/limited_area.py
+++ b/limited_area/limited_area.py
@@ -25,14 +25,18 @@ class LimitedArea():
                  **kwargs):
         """ Init function for Limited Area
 
-        Check to see if mesh file exists and it is the correct type. Check to
-        see that the region file exist and finally set the regionSpec to the
-        requested regionFormat
+        Check to see if all mesh files that were passed in to files exist
+        and that they are all the correct type. Check to see if the first
+        (or only) file contains mesh connectivity. If it is, then load its
+        connectivity fields.
 
+        Add the mesh connectivity mesh to self.mesh, and then add all meshes
+        to the self.meshes attribute. Thus, we can use self.mesh to subset all
+        meshes in the self.meshes attribute in gen_region.
 
         Keyword arguments:
         files        -- Path to valid MPAS mesh files. If multiple files are given, the first file
-                        must contain mesh connectivity infromation, which will be used to subset
+                        must contain mesh connectivity information, which will be used to subset
                         itself, and all following files.
         region       -- Path to pts file region specification 
 
@@ -92,7 +96,8 @@ class LimitedArea():
                 self.meshes.append(MeshHandler(mesh, 'r', *args, **kwargs))
 
     def gen_region(self, *args, **kwargs):
-        """ Generate the boundary region of the given region for the given mesh(es). """
+        """ Generate the boundary region of the specified region
+        and subset meshes in self.meshes """
 
         # Call the regionSpec to generate `name, in_point, boundaries`
         name, inPoint, boundaries= self.regionSpec.gen_spec(self.region_file, **kwargs)
@@ -163,8 +168,8 @@ class LimitedArea():
                                            **kwargs)
 
 
-        # Subset the grid into a new region:
-        print('Subsetting mesh fields into the specified region mesh...')
+        # Create subsets of all the meshes in self.meshes
+        print('Subsetting meshes...')
         for mesh in self.meshes:
             print("\nSubsetting:", mesh.fname)
 
@@ -184,6 +189,8 @@ class LimitedArea():
             print("Create a regional mesh:", regionFname)
 
             if mesh.check_grid():
+                # Save the regional mesh that contains graph connectivity to create the regional
+                # graph partition file below
                 regionalMeshConn = regionalMesh
             else:
                 regionalMesh.mesh.close()

--- a/limited_area/mesh.py
+++ b/limited_area/mesh.py
@@ -94,7 +94,7 @@ class MeshHandler:
 
         return True
 
-    def _load_vars(self):
+    def load_vars(self):
         """ Pre-load variables to avoid multiple, unnecessary IO calls 
             
             Pulling variables from a netCDF4 interface like the following:

--- a/limited_area/mesh.py
+++ b/limited_area/mesh.py
@@ -29,7 +29,7 @@ class MeshHandler:
         self.fname = fname
 
         if mode == 'r':
-            if self.check_file(fname):
+            if self.load_file(fname):
                 return
             else:
                 sys.exit(-1)
@@ -48,15 +48,12 @@ class MeshHandler:
             sys.exit(-1)
 
 
-    def check_file(self, fname):
-        """ Check to see that fname exists and it is a valid NetCDF file """
+    def load_file(self, fname):
+        """ Load fname using the netCDF4 Dataset class. If fname is not a valid NetCDF file, the
+        program will exit. """
         if os.path.isfile(fname):
             try:
-                mesh = open(fname, 'rb')
-                nc_bytes = mesh.read()
-                mesh.close()
-                
-                self.mesh = Dataset(fname, 'r', memory=nc_bytes)
+                self.mesh = Dataset(fname, 'r')
                 return True
             except OSError as E: 
                 print("ERROR: ", E)

--- a/limited_area/mesh.py
+++ b/limited_area/mesh.py
@@ -29,7 +29,6 @@ class MeshHandler:
 
         if mode == 'r':
             if self.check_file(fname):
-                self._load_vars()
                 return
             else:
                 sys.exit(-1)

--- a/limited_area/mesh.py
+++ b/limited_area/mesh.py
@@ -227,7 +227,7 @@ class MeshHandler:
                       format='NETCDF3_64BIT_OFFSET',
                       *args, 
                       **kwargs):
-        """ Subset the current mesh and return a new regional mesh with
+        """ Subset the mesh in self.mesh using mesh and return a new regional mesh with
         subsetted fields 
         
         regionalFname -- Desired filename for the regional subset
@@ -240,6 +240,7 @@ class MeshHandler:
         unmarked      -- The integer value that was used to mark cells,
                          edges, vertices as being 'outside' of the regional
                          mesh.
+        mesh          -- The mesh connectivity to use to subset self.mesh
         """
 
         # Don't pass on DEBUG to the regional mess - tone down output

--- a/limited_area/mesh.py
+++ b/limited_area/mesh.py
@@ -66,6 +66,35 @@ class MeshHandler:
             print("ERROR: This file did not exist!")
             return False
 
+    def check_grid(self):
+        """ Check to see if this mesh contains all of the needed mesh connectivity infromation for
+        subsetting. If it does, return True, and if not, return False. """
+        mesh_dims = ['nCells',
+                     'nEdges',
+                     'maxEdges',
+                     'nVertices',
+                     'vertexDegree']
+
+        mesh_vars = ['latCell',
+                     'lonCell',
+                     'nEdgesOnCell',
+                     'cellsOnCell',
+                     'cellsOnEdge',
+                     'cellsOnVertex',
+                     'indexToCellID',
+                     'indexToEdgeID',
+                     'indexToVertexID',]
+
+        for dim in mesh_dims:
+            if not dim in self.mesh.dimensions:
+                return False
+
+        for var in mesh_vars:
+            if not var in self.mesh.variables:
+                return False
+
+        return True
+
     def _load_vars(self):
         """ Pre-load variables to avoid multiple, unnecessary IO calls 
             


### PR DESCRIPTION
These commits contain a number of changes that allow the MPAS-Limited-Area program to subset multiple mesh files in a single call. The usage of `create_region` remains the same, except that any number of mesh files can be given. 

If multiple files are given, then the first mesh file must contain the needed mesh connectivity fields. The first mesh file's connectivity fields will be used to subset the remaining files. If the first file does not contain mesh connectivity fields, then an error will occur.