### PR TITLE
When opening mesh for reading, don't pre-read entire file into memory buffer

### DIFF
--- a/limited_area/mesh.py
+++ b/limited_area/mesh.py
@@ -52,11 +52,7 @@ class MeshHandler:
         """ Check to see that fname exists and it is a valid NetCDF file """
         if os.path.isfile(fname):
             try:
-                mesh = open(fname, 'rb')
-                nc_bytes = mesh.read()
-                mesh.close()
-                
-                self.mesh = Dataset(fname, 'r', memory=nc_bytes)
+                self.mesh = Dataset(fname, 'r')
                 return True
             except OSError as E: 
                 print("ERROR: ", E)


### PR DESCRIPTION
This PR removes code to pre-read entire input files into memory buffers before opening them with netCDF4.Dataset.

In the MeshHandler class, opening a mesh for reading previously pre-read the entire file into a memory buffer, and then provided that buffer to netCDF4.Dataset with the 'memory' keyword argument. For very large meshes, however, this can lead to memory allocation errors, and so this commit simply creates a new Dataset using the filename of the input mesh.