### PR TITLE
Update usage of `numpy` for compatibility with NumPy 2.x

### DIFF
--- a/limited_area/limited_area.py
+++ b/limited_area/limited_area.py
@@ -374,7 +374,7 @@ class LimitedArea():
             iCell = sourceCell
             while iCell != targetCell:
                 bdyMaskCell[iCell] = self.INSIDE
-                minangle = np.Infinity
+                minangle = np.inf
                 mindist = sphere_distance(mesh.latCells[iCell],
                                           mesh.lonCells[iCell],
                                           mesh.latCells[targetCell],

--- a/limited_area/mesh.py
+++ b/limited_area/mesh.py
@@ -174,11 +174,11 @@ class MeshHandler:
                 nEdgesInterior = nEdgesInterior + 1
 
         with open(graphFname, 'w') as f:
-            f.write(repr(nCells)+' '+repr(nEdgesInterior)+'\n')
+            f.write(str(nCells)+' '+str(nEdgesInterior)+'\n')
             for i in range(nCells):
                 for j in range(nEdgesOnCell[i]):
                     if (cellsOnCell[i,j] > 0):
-                        f.write(repr(cellsOnCell[i,j])+' ')
+                        f.write(str(cellsOnCell[i,j])+' ')
                 f.write('\n')
 
         return graphFname


### PR DESCRIPTION
This PR makes two minor changes for compatibility with NumPy 2.x:
 * The use of `numpy.Infinity` is replaced with `numpy.inf`
 * NumPy `int32` values are converted to strings with `str()` rather than `repr()` when generating `graph.info` files