### PR TITLE
Add -p/--plot option to create_region to produce a plot of region

### DIFF
--- a/create_region
+++ b/create_region
@@ -28,6 +28,8 @@ if __name__ == "__main__":
                           help='Points file specifying the MPAS regional area',
                           type=str)
     required.add_argument('grid',
+                          nargs='?',
+                          default=None,
                           help=('Global MPAS grid file. Either a grid.nc or'
                                 ' static.nc file'),
                           type=str)
@@ -37,8 +39,20 @@ if __name__ == "__main__":
                          type=int,
                          default=0)
 
+    options.add_argument('-p', '--plot',
+                         help='Produce a plot of the region rather than subsetting',
+                         action='store_true')
+
     args, unkown = parser.parse_known_args()
 
+    if args.plot:
+        print('===== Making a plot only! ======')
+    else:
+        if args.grid is None:
+            import sys
+            print('Error: If the -p/--plot option is not specified, a netCDF file')
+            print('  to subset must be provided.')
+            sys.exit(1)
 
     DEBUG = args.verbose
     if  DEBUG > 0:
@@ -53,6 +67,7 @@ if __name__ == "__main__":
 
     regional_area = LimitedArea(args.grid,
                                 args.points,
+                                args.plot,
                                 format='NETCDF3_64BIT_OFFSET',
                                 **kwargs)
 

--- a/limited_area/limited_area.py
+++ b/limited_area/limited_area.py
@@ -458,10 +458,21 @@ class LimitedArea():
                 boundaries[0][1::2] * rad2deg,boundaries[0][0::2] * rad2deg,
                 proj)
 
-            # Here we need a way of determining the "extent" (roughly, the diameter
-            # in meters) of the region given the latbdy and lonbdy arrays
-            extent = 3000000.0
+            # Logic to determine the "extent" (roughly, the diameter in meters)
+            # of the region given the latbdy and lonbdy arrays
+            # Convert all points from lat,lon coordinates to x,y
+            # distances (in meters) from the inPoint
+            xy=proj.transform_points(ccrs.PlateCarree(), lonbdy, latbdy)
 
+            # Find the extents of the box bounding these points and the
+            # diameter (length of diagonal)
+            min_x = min(xy[:,0])
+            max_x = max(xy[:,0])
+            min_y = min(xy[:,1])
+            max_y = max(xy[:,1])
+            diameter = math.sqrt((max_y-min_y)**2+(max_x-min_x)**2)
+
+            extent = diameter
             scaling = 0.5 * 1.25
             ax.set_extent([-scaling * extent, scaling * extent, -scaling * extent, scaling * extent], crs=proj)
 


### PR DESCRIPTION
This PR introduces the ability to make plots of regions without having to subset a netCDF file.

The new `-p`/`--plot` option causes the `create_region` script to create a plot of the specified
region using Matplotlib and Cartopy, without actually subsetting any MPAS netCDF files. The plot
is written to a PNG image file named "region.png".
    
When the `-p`/`--plot` option is specified, no netCDF file needs to be supplied,
since the plot is produced using only user-specified information from the
points file. No subsetting of mesh files takes place when plotting.